### PR TITLE
Support for tables (primarily as output by kable)

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -371,3 +371,25 @@ ul li:before {
     font-size: 12px;
   }
 }
+
+table {
+	border-collapse:collapse;
+	border-top:1px black solid;
+	border-bottom:1px black solid;
+	min-width:100%;
+}
+
+th, td {
+	padding:0.4em;
+}
+
+th { 
+	border-bottom:1px black solid;
+	font-weight:bold;
+}
+
+tr:nth-child(even) {background: #f7f7f7}
+
+caption {
+  font-weight:bold;
+}


### PR DESCRIPTION
I wanted to have tables (via kable.df) in my R blog. I added a minimal style for nice, clean, academic-style tables - example of how it looks:
http://www.martinmodrak.cz/2018/02/02/a-gentle-stan-vs.-inla-comparison/

And thanks for the theme! It looks rad and I am happy you made it.